### PR TITLE
Add execution-only workflow worker API

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+go_version="1.26.0"
+golangci_lint_version="2.12.2"
+bin_dir="$HOME/.local/bin"
+install_dir="$HOME/.local/go${go_version}"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$bin_dir"
+
+if [[ ! -x "$install_dir/bin/go" ]]; then
+	curl --fail --location --silent --show-error \
+		"https://go.dev/dl/go${go_version}.linux-amd64.tar.gz" \
+		--output "$tmp_dir/go.tar.gz"
+	mkdir -p "$install_dir"
+	tar -xzf "$tmp_dir/go.tar.gz" --strip-components=1 -C "$install_dir"
+fi
+
+ln -sfn "$install_dir/bin/go" "$bin_dir/go"
+ln -sfn "$install_dir/bin/gofmt" "$bin_dir/gofmt"
+
+if [[ ! -x "$bin_dir/golangci-lint" ]] || [[ "$($bin_dir/golangci-lint version 2>/dev/null || true)" != *"version ${golangci_lint_version}"* ]]; then
+	curl --fail --location --silent --show-error \
+		"https://github.com/golangci/golangci-lint/releases/download/v${golangci_lint_version}/golangci-lint-${golangci_lint_version}-linux-amd64.tar.gz" \
+		--output "$tmp_dir/golangci-lint.tar.gz"
+	tar -xzf "$tmp_dir/golangci-lint.tar.gz" --strip-components=1 -C "$tmp_dir"
+	install -m 0755 "$tmp_dir/golangci-lint" "$bin_dir/golangci-lint"
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `workflows`: Added `NewWorker`, `Worker.RegisterTasks`, and `Worker.Serve` for execution-only Go workflow release children managed by `tilebox runner start`.
+- `workflows`: Added `GetClient` for accessing the initialized workflows client from a task execution context.
+
+### Changed
+
+- `workflows`: `NewClient` now uses `TILEBOX_API_URL` as its default URL when the environment variable is set.
+
 ## [0.10.0] - 2026-07-01
 
 ### Added

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,7 +21,8 @@ For example, to run the `workflows/helloworld` example:
 go run ./examples/workflows/helloworld
 ```
 
-Workflow examples submit a job first, then start a task runner in the same process.
+Most workflow examples submit a job first, then start a task runner in the same process. The release-worker example is
+an execution-only child managed by `tilebox runner start` and does not poll independently.
 
 ## Workflows examples
 
@@ -29,6 +30,7 @@ Workflow examples submit a job first, then start a task runner in the same proce
 - [MapReduce](workflows/mapreduce): How to fan out tasks and submit dependent reduce tasks.
 - [Progress](workflows/progress): How to report workflow progress.
 - [Protobuf tasks](workflows/protobuf-task): How to use Protobuf tasks.
+- [Go release worker](workflows/release-worker): How to author an execution-only Go child for a workflow release.
 - [Observability](workflows/observability): How to query Tilebox workflow telemetry and export traces/logs to custom Axiom or OpenTelemetry backends.
 
 ## Datasets examples

--- a/examples/workflows/release-worker/README.md
+++ b/examples/workflows/release-worker/README.md
@@ -1,0 +1,18 @@
+# Go Release Worker
+
+This is a complete entry point for a precompiled Go workflow release. It registers tasks and serves the execution-only
+`WorkerService` expected by `tilebox runner start`.
+
+Unlike a direct `TaskRunner`, this program does **not** create a client, select a cluster, poll the task queue, extend
+leases, or report results. The parent Tilebox runner owns those responsibilities and launches this binary with a private
+Unix socket in `TILEBOX_WORKER_ADDRESS`. It lists the registered tasks before initialization, then supplies the API and
+release context used while executing tasks.
+
+The binary is intended to be built by a workflow release `[build.go]` configuration rather than started directly:
+
+```toml
+[build.go]
+package = "./cmd/worker"
+```
+
+See [main.go](main.go) for task registration, progress-compatible context usage, and subtask submission.

--- a/examples/workflows/release-worker/main.go
+++ b/examples/workflows/release-worker/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"log"
+	"log/slog"
+
+	workflows "github.com/tilebox/tilebox-go/workflows/v1"
+)
+
+type ProcessScene struct {
+	SceneID string `json:"scene_id"`
+}
+
+func (*ProcessScene) Identifier() workflows.TaskIdentifier {
+	return workflows.NewTaskIdentifier("example.com/scenes/process", "v1.0")
+}
+
+func (task *ProcessScene) Execute(ctx context.Context) error {
+	slog.InfoContext(ctx, "processing scene", slog.String("scene_id", task.SceneID))
+	_, err := workflows.SubmitSubtask(ctx, &WriteSummary{SceneID: task.SceneID})
+	return err
+}
+
+type WriteSummary struct {
+	SceneID string `json:"scene_id"`
+}
+
+func (*WriteSummary) Identifier() workflows.TaskIdentifier {
+	return workflows.NewTaskIdentifier("example.com/scenes/write-summary", "v1.0")
+}
+
+func (task *WriteSummary) Execute(ctx context.Context) error {
+	slog.InfoContext(ctx, "writing scene summary", slog.String("scene_id", task.SceneID))
+	return nil
+}
+
+func main() {
+	worker := workflows.NewWorker()
+	if err := worker.RegisterTasks(
+		&ProcessScene{},
+		&WriteSummary{},
+	); err != nil {
+		log.Fatal(err)
+	}
+	if err := worker.Serve(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/workflows/v1/client.go
+++ b/workflows/v1/client.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	otelTracerName = "tilebox.com/observability"
-	otelMeterName  = otelTracerName
+	defaultTileboxAPIURL = "https://api.tilebox.com"
+	otelTracerName       = "tilebox.com/observability"
+	otelMeterName        = otelTracerName
 )
 
 // Client is a Tilebox Workflows client.
@@ -38,7 +39,7 @@ type Client struct {
 // NewClient creates a new Tilebox Workflows client.
 //
 // By default, the returned Client is configured with:
-//   - "https://api.tilebox.com" as the URL
+//   - environment variable TILEBOX_API_URL as the URL, or "https://api.tilebox.com" when unset
 //   - environment variable TILEBOX_API_KEY as the API key
 //   - a grpc.RetryHTTPClient HTTP client
 //   - the global tracer provider
@@ -48,7 +49,10 @@ type Client struct {
 func NewClient(options ...ClientOption) *Client {
 	cfg := newClientConfig(options)
 	configureTileboxTelemetry(context.Background(), cfg)
+	return newClient(cfg)
+}
 
+func newClient(cfg *clientConfig) *Client {
 	jobConnectClient := newConnectClient(workflowsv1connect.NewJobServiceClient, cfg)
 	telemetryConnectClient := newConnectClient(workflowsv1connect.NewTelemetryQueryServiceClient, cfg)
 	taskConnectClient := newConnectClient(workflowsv1connect.NewTaskServiceClient, cfg)
@@ -77,7 +81,7 @@ func NewClient(options ...ClientOption) *Client {
 //   - runner.WithRunnerLogger: sets the logger to use for the task runner. Defaults to slog.Default().
 //   - runner.WithDisableMetrics: disables OpenTelemetry metrics for the task runner.
 func (c *Client) NewTaskRunner(ctx context.Context, options ...runner.Option) (*TaskRunner, error) {
-	return newTaskRunner(ctx, c.taskService, c.Clusters, c.tracer, options...)
+	return newTaskRunnerWithClient(ctx, c, c.taskService, c.Clusters, c.tracer, options...)
 }
 
 // NewPollingTaskRunner creates a polling task runner for custom task executors.
@@ -166,8 +170,12 @@ func WithDisableLogging() ClientOption {
 }
 
 func newClientConfig(options []ClientOption) *clientConfig {
+	apiURL := os.Getenv("TILEBOX_API_URL")
+	if apiURL == "" {
+		apiURL = defaultTileboxAPIURL
+	}
 	cfg := &clientConfig{
-		url:            "https://api.tilebox.com",
+		url:            apiURL,
 		apiKey:         os.Getenv("TILEBOX_API_KEY"),
 		tracerProvider: otel.GetTracerProvider(), // use the global tracer provider by default
 	}

--- a/workflows/v1/polling_runner_test.go
+++ b/workflows/v1/polling_runner_test.go
@@ -186,6 +186,8 @@ func TestPollingTaskRunnerRetriesTaskFailedRequestErrorOnceAsWorkflowFailure(t *
 
 func TestPollingTaskRunnerStopsRetryingTaskFailedAfterSecondRequestError(t *testing.T) {
 	taskID := uuid.New()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	mockNextTask := workflowsv1.Task_builder{
 		Id: tileboxv1.NewUUID(taskID),
 		Identifier: workflowsv1.TaskIdentifier_builder{
@@ -204,6 +206,11 @@ func TestPollingTaskRunnerStopsRetryingTaskFailedAfterSecondRequestError(t *test
 			connect.NewError(connect.CodeInvalidArgument, errors.New("invalid failed task request")),
 			connect.NewError(connect.CodeInvalidArgument, errors.New("still invalid")),
 		},
+		taskFailedHook: func(requests int) {
+			if requests == 2 {
+				cancel()
+			}
+		},
 	}
 	executor := &failedResponseExecutor{
 		response: workflowsv1.ExecuteTaskResponse_builder{
@@ -214,8 +221,6 @@ func TestPollingTaskRunnerStopsRetryingTaskFailedAfterSecondRequestError(t *test
 		}.Build(),
 	}
 	runner := NewPollingTaskRunner(service, "default", executor, slog.Default())
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-	defer cancel()
 
 	require.NoError(t, runner.RunAll(ctx))
 
@@ -274,6 +279,7 @@ type requestErrorTaskService struct {
 	nextTaskComputedTaskErr       error
 	taskFailedErrors              []error
 	taskFailedRequests            []*workflowsv1.TaskFailedRequest
+	taskFailedHook                func(requests int)
 }
 
 var _ TaskService = &requestErrorTaskService{}
@@ -303,6 +309,9 @@ func (s *requestErrorTaskService) TaskFailed(_ context.Context, taskID uuid.UUID
 		WasWorkflowError: wasWorkflowError,
 		ProgressUpdates:  progressUpdates,
 	}.Build())
+	if s.taskFailedHook != nil {
+		s.taskFailedHook(len(s.taskFailedRequests))
+	}
 	if len(s.taskFailedErrors) > 0 {
 		err := s.taskFailedErrors[0]
 		s.taskFailedErrors = s.taskFailedErrors[1:]

--- a/workflows/v1/runner.go
+++ b/workflows/v1/runner.go
@@ -8,19 +8,15 @@ import (
 	"log/slog"
 	"math"
 	"os/signal"
-	"reflect"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/tilebox/tilebox-go/internal/span"
-	obslogger "github.com/tilebox/tilebox-go/observability/logger"
 	tileboxv1 "github.com/tilebox/tilebox-go/protogen/tilebox/v1"
 	workflowsv1 "github.com/tilebox/tilebox-go/protogen/workflows/v1"
 	"github.com/tilebox/tilebox-go/workflows/v1/runner"
 	"github.com/tilebox/tilebox-go/workflows/v1/subtask"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
@@ -116,17 +112,16 @@ func newTaskRunnerMetrics(meter metric.Meter) (*taskRunnerMetrics, error) {
 //
 // Documentation: https://docs.tilebox.com/workflows/concepts/task-runners
 type TaskRunner struct {
-	pollingRunner   *PollingTaskRunner
-	service         TaskService
-	taskDefinitions map[taskIdentifier]ExecutableTask
-
-	cluster string
-	tracer  trace.Tracer
-	logger  *slog.Logger
-	metrics *taskRunnerMetrics
+	pollingRunner *PollingTaskRunner
+	service       TaskService
+	executor      *taskExecutor
 }
 
-func newTaskRunner(ctx context.Context, service TaskService, clusterClient ClusterClient, tracer trace.Tracer, options ...runner.Option) (*TaskRunner, error) {
+func newTaskRunner(ctx context.Context, service TaskService, clusterClient ClusterClient, tracer trace.Tracer) (*TaskRunner, error) {
+	return newTaskRunnerWithClient(ctx, nil, service, clusterClient, tracer)
+}
+
+func newTaskRunnerWithClient(ctx context.Context, client *Client, service TaskService, clusterClient ClusterClient, tracer trace.Tracer, options ...runner.Option) (*TaskRunner, error) {
 	opts := &runner.Options{
 		ClusterSlug:   "",
 		Logger:        slog.Default(),
@@ -141,19 +136,14 @@ func newTaskRunner(ctx context.Context, service TaskService, clusterClient Clust
 		return nil, fmt.Errorf("failed to get cluster: %w", err)
 	}
 
-	metrics, err := newTaskRunnerMetrics(opts.MeterProvider.Meter(otelMeterName))
+	executor, err := newTaskExecutor(newTaskRegistry(), cluster.Slug, client, tracer, opts.Logger, opts.MeterProvider)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create task runner metrics: %w", err)
+		return nil, err
 	}
 
 	taskRunner := &TaskRunner{
-		service:         service,
-		taskDefinitions: make(map[taskIdentifier]ExecutableTask),
-
-		cluster: cluster.Slug,
-		tracer:  tracer,
-		logger:  opts.Logger,
-		metrics: metrics,
+		service:  service,
+		executor: executor,
 	}
 	taskRunner.pollingRunner = NewPollingTaskRunner(service, cluster.Slug, taskRunner, opts.Logger)
 	return taskRunner, nil
@@ -161,19 +151,12 @@ func newTaskRunner(ctx context.Context, service TaskService, clusterClient Clust
 
 // GetRegisteredTask returns the task with the given identifier.
 func (t *TaskRunner) GetRegisteredTask(identifier TaskIdentifier) (ExecutableTask, bool) {
-	registeredTask, found := t.taskDefinitions[taskIdentifier{name: identifier.Name(), version: identifier.Version()}]
-	return registeredTask, found
+	return t.executor.registry.get(identifier)
 }
 
 // RegisterTasks makes the task runner aware of multiple tasks.
 func (t *TaskRunner) RegisterTasks(tasks ...ExecutableTask) error {
-	for _, task := range tasks {
-		err := t.registerTask(task)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return t.executor.registry.registerTasks(tasks...)
 }
 
 func isEmpty(id *tileboxv1.ID) bool {
@@ -195,152 +178,22 @@ func (t *TaskRunner) RunAll(ctx context.Context) error {
 }
 
 func (t *TaskRunner) TaskIdentifiers() []*workflowsv1.TaskIdentifier {
-	identifiers := make([]*workflowsv1.TaskIdentifier, 0, len(t.taskDefinitions))
-	for _, task := range t.taskDefinitions {
-		identifier := identifierFromTask(task)
-		identifiers = append(identifiers, workflowsv1.TaskIdentifier_builder{
-			Name:    identifier.Name(),
-			Version: identifier.Version(),
-		}.Build())
-	}
-	return identifiers
+	return t.executor.registry.identifiers()
 }
 
 func (t *TaskRunner) ExecuteTask(ctx context.Context, task *workflowsv1.Task) (*workflowsv1.ExecuteTaskResponse, error) {
-	executionContext, err := t.executeTask(ctx, task)
-	if err != nil {
-		var progressUpdates []*workflowsv1.Progress
-		if executionContext != nil {
-			progressUpdates = executionContext.getProgressUpdates()
-		}
-		failedTask := workflowsv1.TaskFailedRequest_builder{
-			TaskId:           task.GetId(),
-			Display:          failedTaskDisplay(task.GetDisplay(), err),
-			WasWorkflowError: true,
-			ProgressUpdates:  progressUpdates,
-		}.Build()
-		return workflowsv1.ExecuteTaskResponse_builder{FailedTask: failedTask}.Build(), nil
+	response, err := t.executor.ExecuteTask(ctx, task)
+	if response.GetFailedTask() != nil {
+		// TaskRunner historically treats every native execution failure as a workflow error. Keep that behavior for
+		// direct polling runners while WorkerService can distinguish setup/routing failures.
+		response.GetFailedTask().SetWasWorkflowError(true)
 	}
-
-	computedTask := workflowsv1.ComputedTask_builder{
-		Id:              task.GetId(),
-		Display:         task.GetDisplay(),
-		SubTasks:        executionContext.getSubTasks(),
-		ProgressUpdates: executionContext.getProgressUpdates(),
-	}.Build()
-	return workflowsv1.ExecuteTaskResponse_builder{ComputedTask: computedTask}.Build(), nil
-}
-
-func (t *TaskRunner) executeTask(ctx context.Context, task *workflowsv1.Task) (*taskExecutionContext, error) {
-	// actually execute the task
-	beforeTime := time.Now().UTC()
-
-	if task.GetIdentifier() == nil {
-		return nil, errors.New("task has no identifier")
-	}
-	identifier := NewTaskIdentifier(task.GetIdentifier().GetName(), task.GetIdentifier().GetVersion())
-	taskPrototype, found := t.GetRegisteredTask(identifier)
-	if !found {
-		return nil, fmt.Errorf("task %s is not registered on this runner", task.GetIdentifier().GetName())
-	}
-
-	return span.StartJobSpan(ctx, t.tracer, fmt.Sprintf("task/%s", identifier.Name()), task.GetJob(), func(ctx context.Context) (taskExecutionContext *taskExecutionContext, err error) { //nolint:nonamedreturns // needed to return a value in case of panic
-		t.logger.DebugContext(ctx, "executing task",
-			slog.String("task_id", task.GetId().AsUUID().String()),
-			slog.String("task", identifier.Name()),
-			slog.String("version", identifier.Version()),
-		)
-		taskStruct := reflect.New(reflect.ValueOf(taskPrototype).Elem().Type()).Interface().(ExecutableTask)
-
-		_, isProtobuf := taskStruct.(proto.Message)
-		if isProtobuf {
-			err := proto.Unmarshal(task.GetInput(), taskStruct.(proto.Message))
-			if err != nil {
-				return nil, fmt.Errorf("failed to unmarshal protobuf task: %w", err)
-			}
-		} else {
-			err := json.Unmarshal(task.GetInput(), taskStruct)
-			if err != nil {
-				return nil, fmt.Errorf("failed to unmarshal json task: %w", err)
-			}
-		}
-
-		log := t.logger.With(
-			slog.String("job_id", task.GetJob().GetId().AsUUID().String()),
-			slog.String("task", identifier.Name()),
-			slog.String("version", identifier.Version()),
-			slog.Time("start_time", beforeTime),
-		)
-
-		taskMetricAttributes := metric.WithAttributes(attribute.String("task_identifier", identifier.Name()), attribute.String("task_version", identifier.Version()))
-
-		defer func() {
-			if r := recover(); r != nil {
-				// recover from panics during task executions, so we can still report the error to the server and continue
-				// with other tasks
-				log.ErrorContext(ctx, "task execution failed", slog.String("error", "panic"), slog.Int64("retry_attempt", task.GetRetryCount()))
-				taskExecutionContext = nil
-				err = fmt.Errorf("task panicked: %v", r)
-
-				// also instrument the panic as a failed task execution
-				t.metrics.tasksFailedMetric.Add(ctx, 1, taskMetricAttributes)
-				t.metrics.taskExecutionDurationMetric.Record(ctx, time.Since(beforeTime).Seconds(), taskMetricAttributes, metric.WithAttributes(attribute.String("state", "failed")))
-			}
-		}()
-
-		t.metrics.taskInputSizeMetric.Record(ctx, int64(len(task.GetInput())), taskMetricAttributes)
-		t.metrics.tasksExecutedMetric.Add(ctx, 1, taskMetricAttributes)
-
-		executionContext := t.withTaskExecutionContext(ctx, task)
-		executionContext = obslogger.ContextWithSlogAttributes(executionContext, slog.String("task_id", task.GetId().AsUUID().String()))
-		err = taskStruct.Execute(executionContext)
-
-		executionTime := time.Since(beforeTime)
-		log = log.With(
-			slog.Duration("execution_time", executionTime),
-			slog.String("execution_time_human", roundDuration(executionTime, 2).String()),
-		)
-
-		if err != nil {
-			t.metrics.tasksFailedMetric.Add(ctx, 1, taskMetricAttributes)
-			t.metrics.taskExecutionDurationMetric.Record(ctx, executionTime.Seconds(), taskMetricAttributes, metric.WithAttributes(attribute.String("state", "failed")))
-
-			log.ErrorContext(executionContext, "task execution failed", slog.Any("error", err), slog.Int64("retry_attempt", task.GetRetryCount()))
-			return getTaskExecutionContext(executionContext), fmt.Errorf("failed to execute task: %w", err)
-		}
-
-		t.metrics.tasksComputedMetric.Add(ctx, 1, taskMetricAttributes)
-		t.metrics.taskExecutionDurationMetric.Record(ctx, executionTime.Seconds(), taskMetricAttributes, metric.WithAttributes(attribute.String("state", "computed")))
-
-		return getTaskExecutionContext(executionContext), nil
-	})
-}
-
-// extendTaskLease is a function designed to be run as a goroutine, extending the lease of a task continuously until the
-// context is cancelled, which indicates that the execution of the task is finished.
-// registerTask makes the task runner aware of a task.
-func (t *TaskRunner) registerTask(task ExecutableTask) error {
-	identifier := identifierFromTask(task)
-	err := ValidateIdentifier(identifier)
-	if err != nil {
-		return err
-	}
-	key := taskIdentifier{name: identifier.Name(), version: identifier.Version()}
-	_, found := t.taskDefinitions[key]
-	if found {
-		return fmt.Errorf(
-			"duplicate task identifier: a task '%s' with version '%s' is already registered",
-			identifier.Name(),
-			identifier.Version(),
-		)
-	}
-	t.taskDefinitions[key] = task
-	return nil
+	return response, err
 }
 
 type taskExecutionContext struct {
 	CurrentTask *workflowsv1.Task
-	runner      *TaskRunner
+	executor    *taskExecutor
 
 	subtasksMutex sync.Mutex
 	subtasks      []*futureTask
@@ -356,11 +209,13 @@ func (e *taskExecutionContext) getProgressUpdates() []*workflowsv1.Progress {
 	defer e.progressMutex.Unlock()
 	progressUpdates := make([]*workflowsv1.Progress, 0, len(e.progressIndicators))
 	for _, progress := range e.progressIndicators {
+		progress.mutex.Lock()
 		progressUpdates = append(progressUpdates, workflowsv1.Progress_builder{
 			Label: progress.label,
 			Total: progress.total,
 			Done:  progress.done,
 		}.Build())
+		progress.mutex.Unlock()
 	}
 	return progressUpdates
 }
@@ -373,14 +228,7 @@ func (e *taskExecutionContext) getSubTasks() *workflowsv1.TaskSubmissions {
 }
 
 func (t *TaskRunner) withTaskExecutionContext(ctx context.Context, task *workflowsv1.Task) context.Context {
-	return context.WithValue(ctx, contextKeyTaskExecution, &taskExecutionContext{
-		CurrentTask:        task,
-		runner:             t,
-		subtasksMutex:      sync.Mutex{},
-		subtasks:           make([]*futureTask, 0),
-		progressIndicators: make(map[string]*taskProgressIndicator),
-		progressMutex:      sync.Mutex{},
-	})
+	return t.executor.withTaskExecutionContext(ctx, task)
 }
 
 func getTaskExecutionContext(ctx context.Context) *taskExecutionContext {
@@ -399,7 +247,19 @@ func GetCurrentCluster(ctx context.Context) (string, error) {
 	if executionContext == nil {
 		return "", errors.New("cannot get current cluster without task execution context")
 	}
-	return executionContext.runner.cluster, nil
+	return executionContext.executor.cluster, nil
+}
+
+// GetClient returns the authenticated workflows client for the current task execution.
+//
+// A client is available for tasks run by a Client-created TaskRunner and by an initialized Worker. The client uses
+// the execution runtime's configured API connection, so callers should pass the task context to client operations.
+func GetClient(ctx context.Context) (*Client, error) {
+	executionContext := getTaskExecutionContext(ctx)
+	if executionContext == nil || executionContext.executor.client == nil {
+		return nil, errors.New("cannot get workflows client without initialized task execution context")
+	}
+	return executionContext.executor.client, nil
 }
 
 // SetTaskDisplay sets the label name of the current task.
@@ -426,7 +286,7 @@ func SubmitSubtask(ctx context.Context, task Task, options ...subtask.SubmitOpti
 
 	opts := &subtask.SubmitOptions{
 		Dependencies: nil,
-		ClusterSlug:  executionContext.runner.cluster,
+		ClusterSlug:  executionContext.executor.cluster,
 		MaxRetries:   0,
 		Optional:     false,
 	}

--- a/workflows/v1/runner_test.go
+++ b/workflows/v1/runner_test.go
@@ -163,7 +163,7 @@ func TestTaskRunner_RegisterTasks(t *testing.T) {
 
 			require.NoError(t, err)
 
-			assert.Len(t, runner.taskDefinitions, len(tt.wantTasks))
+			assert.Len(t, runner.executor.registry.definitions, len(tt.wantTasks))
 			for _, task := range tt.wantTasks {
 				identifier := identifierFromTask(task)
 				_, ok := runner.GetRegisteredTask(identifier)
@@ -215,6 +215,7 @@ func Test_isEmpty(t *testing.T) {
 // mockMinimalTaskService is a mock task service that returns a single next task response. after that it returns an empty response every time
 type mockMinimalTaskService struct {
 	computedTasks          []*workflowsv1.ComputedTask
+	computedTaskReported   chan struct{}
 	nextTask               *workflowsv1.Task
 	idlingDuration         time.Duration
 	failed                 bool
@@ -228,6 +229,12 @@ var _ TaskService = &mockMinimalTaskService{}
 func (m *mockMinimalTaskService) NextTask(_ context.Context, computedTask *workflowsv1.ComputedTask, _ *workflowsv1.NextTaskToRun) (*workflowsv1.NextTaskResponse, error) {
 	if computedTask != nil {
 		m.computedTasks = append(m.computedTasks, computedTask)
+		if m.computedTaskReported != nil {
+			select {
+			case m.computedTaskReported <- struct{}{}:
+			default:
+			}
+		}
 	}
 
 	if m.nextTask != nil {
@@ -292,7 +299,8 @@ func TestTaskRunner_RunForever(t *testing.T) {
 			TraceParent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
 		}.Build(),
 	}.Build()
-	mockTaskClient := &mockMinimalTaskService{nextTask: mockNextTask}
+	computedTaskReported := make(chan struct{}, 1)
+	mockTaskClient := &mockMinimalTaskService{nextTask: mockNextTask, computedTaskReported: computedTaskReported}
 
 	tracer := noop.NewTracerProvider().Tracer("")
 	service := mockTaskService{}
@@ -304,8 +312,15 @@ func TestTaskRunner_RunForever(t *testing.T) {
 	err = runner.RegisterTasks(task)
 	require.NoError(t, err, "failed to register task")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond) // run our one task, then stop
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	go func() {
+		select {
+		case <-computedTaskReported:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
 	require.NoError(t, runner.RunForever(ctx))
 
 	assert.False(t, mockTaskClient.failed, "task should not have failed")

--- a/workflows/v1/task.go
+++ b/workflows/v1/task.go
@@ -79,6 +79,9 @@ func identifierFromTask(task Task) TaskIdentifier {
 
 // ValidateIdentifier performs client-side validation on a task identifier.
 func ValidateIdentifier(identifier TaskIdentifier) error {
+	if identifier == nil {
+		return errors.New("task identifier is nil")
+	}
 	if identifier.Name() == "" {
 		return errors.New("task name is empty")
 	}

--- a/workflows/v1/task_executor.go
+++ b/workflows/v1/task_executor.go
@@ -1,0 +1,265 @@
+package workflows
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/tilebox/tilebox-go/internal/span"
+	obslogger "github.com/tilebox/tilebox-go/observability/logger"
+	workflowsv1 "github.com/tilebox/tilebox-go/protogen/workflows/v1"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/proto"
+)
+
+type taskRegistry struct {
+	mu          sync.RWMutex
+	definitions map[taskIdentifier]ExecutableTask
+	order       []taskIdentifier
+}
+
+func newTaskRegistry() *taskRegistry {
+	return &taskRegistry{definitions: make(map[taskIdentifier]ExecutableTask)}
+}
+
+func (r *taskRegistry) registerTasks(tasks ...ExecutableTask) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, task := range tasks {
+		if err := validateExecutableTask(task); err != nil {
+			return err
+		}
+
+		identifier := identifierFromTask(task)
+		if err := ValidateIdentifier(identifier); err != nil {
+			return err
+		}
+
+		key := taskIdentifier{name: identifier.Name(), version: identifier.Version()}
+		if _, found := r.definitions[key]; found {
+			return fmt.Errorf(
+				"duplicate task identifier: a task '%s' with version '%s' is already registered",
+				identifier.Name(),
+				identifier.Version(),
+			)
+		}
+		r.definitions[key] = task
+		r.order = append(r.order, key)
+	}
+	return nil
+}
+
+func validateExecutableTask(task ExecutableTask) error {
+	if task == nil {
+		return errors.New("cannot register nil task")
+	}
+	taskType := reflect.TypeOf(task)
+	taskValue := reflect.ValueOf(task)
+	if taskType.Kind() != reflect.Pointer || taskType.Elem().Kind() != reflect.Struct || taskValue.IsNil() {
+		return fmt.Errorf("task %T must be a non-nil pointer to a struct", task)
+	}
+	return nil
+}
+
+func (r *taskRegistry) get(identifier TaskIdentifier) (ExecutableTask, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	registeredTask, found := r.definitions[taskIdentifier{name: identifier.Name(), version: identifier.Version()}]
+	return registeredTask, found
+}
+
+func (r *taskRegistry) identifiers() []*workflowsv1.TaskIdentifier {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	identifiers := make([]*workflowsv1.TaskIdentifier, 0, len(r.order))
+	for _, identifier := range r.order {
+		identifiers = append(identifiers, workflowsv1.TaskIdentifier_builder{
+			Name:    identifier.name,
+			Version: identifier.version,
+		}.Build())
+	}
+	return identifiers
+}
+
+type classifiedTaskError struct {
+	err              error
+	wasWorkflowError bool
+}
+
+func (e *classifiedTaskError) Error() string {
+	return e.err.Error()
+}
+
+func (e *classifiedTaskError) Unwrap() error {
+	return e.err
+}
+
+type taskExecutor struct {
+	registry *taskRegistry
+
+	cluster string
+	client  *Client
+	tracer  trace.Tracer
+	logger  *slog.Logger
+	metrics *taskRunnerMetrics
+
+	redactError  func(error) error
+	redactString func(string) string
+}
+
+func newTaskExecutor(
+	registry *taskRegistry,
+	cluster string,
+	client *Client,
+	tracer trace.Tracer,
+	logger *slog.Logger,
+	meterProvider metric.MeterProvider,
+) (*taskExecutor, error) {
+	metrics, err := newTaskRunnerMetrics(meterProvider.Meter(otelMeterName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create task runner metrics: %w", err)
+	}
+	return &taskExecutor{
+		registry:     registry,
+		cluster:      cluster,
+		client:       client,
+		tracer:       tracer,
+		logger:       logger,
+		metrics:      metrics,
+		redactError:  func(err error) error { return err },
+		redactString: func(value string) string { return value },
+	}, nil
+}
+
+func (e *taskExecutor) ExecuteTask(ctx context.Context, task *workflowsv1.Task) (*workflowsv1.ExecuteTaskResponse, error) {
+	executionContext, err := e.executeTask(ctx, task)
+	if err != nil {
+		wasWorkflowError := false
+		var classifiedError *classifiedTaskError
+		if errors.As(err, &classifiedError) {
+			wasWorkflowError = classifiedError.wasWorkflowError
+		}
+		err = e.redactError(err)
+
+		var progressUpdates []*workflowsv1.Progress
+		if executionContext != nil {
+			progressUpdates = executionContext.getProgressUpdates()
+		}
+		failedTask := workflowsv1.TaskFailedRequest_builder{
+			TaskId:           task.GetId(),
+			Display:          failedTaskDisplay(e.redactString(task.GetDisplay()), err),
+			WasWorkflowError: wasWorkflowError,
+			ProgressUpdates:  progressUpdates,
+		}.Build()
+		return workflowsv1.ExecuteTaskResponse_builder{FailedTask: failedTask}.Build(), nil
+	}
+
+	computedTask := workflowsv1.ComputedTask_builder{
+		Id:              task.GetId(),
+		Display:         e.redactString(task.GetDisplay()),
+		SubTasks:        executionContext.getSubTasks(),
+		ProgressUpdates: executionContext.getProgressUpdates(),
+	}.Build()
+	return workflowsv1.ExecuteTaskResponse_builder{ComputedTask: computedTask}.Build(), nil
+}
+
+func (e *taskExecutor) executeTask(ctx context.Context, task *workflowsv1.Task) (*taskExecutionContext, error) {
+	beforeTime := time.Now().UTC()
+
+	if task.GetIdentifier() == nil {
+		return nil, &classifiedTaskError{err: errors.New("task has no identifier")}
+	}
+	identifier := NewTaskIdentifier(task.GetIdentifier().GetName(), task.GetIdentifier().GetVersion())
+	taskPrototype, found := e.registry.get(identifier)
+	if !found {
+		return nil, &classifiedTaskError{
+			err: fmt.Errorf("task %s@%s is not registered on this runner", identifier.Name(), identifier.Version()),
+		}
+	}
+
+	return span.StartJobSpan(ctx, e.tracer, fmt.Sprintf("task/%s", identifier.Name()), task.GetJob(), func(ctx context.Context) (taskExecutionContext *taskExecutionContext, err error) { //nolint:nonamedreturns // needed to return state after a recovered panic
+		e.logger.DebugContext(ctx, "executing task",
+			slog.String("task_id", task.GetId().AsUUID().String()),
+			slog.String("task", identifier.Name()),
+			slog.String("version", identifier.Version()),
+		)
+
+		log := e.logger.With(
+			slog.String("job_id", task.GetJob().GetId().AsUUID().String()),
+			slog.String("task", identifier.Name()),
+			slog.String("version", identifier.Version()),
+			slog.Time("start_time", beforeTime),
+		)
+		taskMetricAttributes := metric.WithAttributes(
+			attribute.String("task_identifier", identifier.Name()),
+			attribute.String("task_version", identifier.Version()),
+		)
+
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				panicError := e.redactError(fmt.Errorf("task panicked: %v", recovered))
+				log.ErrorContext(ctx, "task execution failed", slog.String("error", panicError.Error()), slog.Int64("retry_attempt", task.GetRetryCount()))
+				err = &classifiedTaskError{err: panicError, wasWorkflowError: true}
+
+				e.metrics.tasksFailedMetric.Add(ctx, 1, taskMetricAttributes)
+				e.metrics.taskExecutionDurationMetric.Record(ctx, time.Since(beforeTime).Seconds(), taskMetricAttributes, metric.WithAttributes(attribute.String("state", "failed")))
+			}
+		}()
+
+		taskStruct := reflect.New(reflect.TypeOf(taskPrototype).Elem()).Interface().(ExecutableTask)
+		if taskMessage, isProtobuf := taskStruct.(proto.Message); isProtobuf {
+			if err := proto.Unmarshal(task.GetInput(), taskMessage); err != nil {
+				return nil, &classifiedTaskError{err: fmt.Errorf("failed to unmarshal protobuf task: %w", err), wasWorkflowError: true}
+			}
+		} else if err := json.Unmarshal(task.GetInput(), taskStruct); err != nil {
+			return nil, &classifiedTaskError{err: fmt.Errorf("failed to unmarshal json task: %w", err), wasWorkflowError: true}
+		}
+
+		e.metrics.taskInputSizeMetric.Record(ctx, int64(len(task.GetInput())), taskMetricAttributes)
+		e.metrics.tasksExecutedMetric.Add(ctx, 1, taskMetricAttributes)
+
+		executionContext := e.withTaskExecutionContext(ctx, task)
+		executionContext = obslogger.ContextWithSlogAttributes(executionContext, slog.String("task_id", task.GetId().AsUUID().String()))
+		err = taskStruct.Execute(executionContext)
+
+		executionTime := time.Since(beforeTime)
+		log = log.With(
+			slog.Duration("execution_time", executionTime),
+			slog.String("execution_time_human", roundDuration(executionTime, 2).String()),
+		)
+
+		if err != nil {
+			err = e.redactError(err)
+			e.metrics.tasksFailedMetric.Add(ctx, 1, taskMetricAttributes)
+			e.metrics.taskExecutionDurationMetric.Record(ctx, executionTime.Seconds(), taskMetricAttributes, metric.WithAttributes(attribute.String("state", "failed")))
+			log.ErrorContext(executionContext, "task execution failed", slog.String("error", err.Error()), slog.Int64("retry_attempt", task.GetRetryCount()))
+			return getTaskExecutionContext(executionContext), &classifiedTaskError{
+				err:              fmt.Errorf("failed to execute task: %w", err),
+				wasWorkflowError: true,
+			}
+		}
+
+		e.metrics.tasksComputedMetric.Add(ctx, 1, taskMetricAttributes)
+		e.metrics.taskExecutionDurationMetric.Record(ctx, executionTime.Seconds(), taskMetricAttributes, metric.WithAttributes(attribute.String("state", "computed")))
+
+		return getTaskExecutionContext(executionContext), nil
+	})
+}
+
+func (e *taskExecutor) withTaskExecutionContext(ctx context.Context, task *workflowsv1.Task) context.Context {
+	return context.WithValue(ctx, contextKeyTaskExecution, &taskExecutionContext{
+		CurrentTask:        task,
+		executor:           e,
+		subtasks:           make([]*futureTask, 0),
+		progressIndicators: make(map[string]*taskProgressIndicator),
+	})
+}

--- a/workflows/v1/telemetry.go
+++ b/workflows/v1/telemetry.go
@@ -31,6 +31,7 @@ var (
 	tileboxTraceProviders   sync.Map
 	slogHandlersMu          sync.Mutex
 	slogHandlers            []slog.Handler
+	slogBaseLogger          *slog.Logger
 )
 
 // ConfigureConsoleLogging configures the default slog logger to write logs to stdout at the given level.
@@ -48,22 +49,22 @@ func ConfigureConsoleLogging(level slog.Level) {
 // If ctx is not a task execution context or the task runner has no tracer, f is called without creating a span.
 func WithSpanResult[Result any](ctx context.Context, name string, f func(ctx context.Context) (Result, error)) (Result, error) {
 	executionContext := getTaskExecutionContext(ctx)
-	if executionContext == nil || executionContext.runner.tracer == nil {
+	if executionContext == nil || executionContext.executor.tracer == nil {
 		return f(ctx)
 	}
 
-	return observability.WithSpanResult(ctx, executionContext.runner.tracer, name, f)
+	return observability.WithSpanResult(ctx, executionContext.executor.tracer, name, f)
 }
 
 // WithSpan wraps f with a tracing span using the current task runner's tracer.
 // If ctx is not a task execution context or the task runner has no tracer, f is called without creating a span.
 func WithSpan(ctx context.Context, name string, f func(ctx context.Context) error) error {
 	executionContext := getTaskExecutionContext(ctx)
-	if executionContext == nil || executionContext.runner.tracer == nil {
+	if executionContext == nil || executionContext.executor.tracer == nil {
 		return f(ctx)
 	}
 
-	return observability.WithSpan(ctx, executionContext.runner.tracer, name, f)
+	return observability.WithSpan(ctx, executionContext.executor.tracer, name, f)
 }
 
 func configureTileboxTelemetry(ctx context.Context, cfg *clientConfig) {
@@ -159,9 +160,13 @@ func NewTileboxLogHandler(ctx context.Context, apiURL string, apiKey string, lev
 func configureSlogHandler(handler slog.Handler) {
 	slogHandlersMu.Lock()
 	defer slogHandlersMu.Unlock()
+	configureSlogHandlerLocked(handler)
+}
 
+func configureSlogHandlerLocked(handler slog.Handler) {
 	if len(slogHandlers) == 0 {
-		existingHandler := slog.Default().Handler()
+		slogBaseLogger = slog.Default()
+		existingHandler := slogBaseLogger.Handler()
 		if !isDefaultSlogHandler(existingHandler) {
 			slogHandlers = append(slogHandlers, existingHandler)
 		}
@@ -169,6 +174,41 @@ func configureSlogHandler(handler slog.Handler) {
 
 	slogHandlers = append(slogHandlers, handler)
 	slog.SetDefault(logger.New(slogHandlers...))
+}
+
+type removableSlogHandler struct {
+	slog.Handler
+}
+
+func configureRemovableSlogHandler(handler slog.Handler) func() {
+	registeredHandler := &removableSlogHandler{Handler: handler}
+	slogHandlersMu.Lock()
+	configureSlogHandlerLocked(registeredHandler)
+	slogHandlersMu.Unlock()
+
+	var removeOnce sync.Once
+	return func() {
+		removeOnce.Do(func() {
+			slogHandlersMu.Lock()
+			defer slogHandlersMu.Unlock()
+
+			for i, configuredHandler := range slogHandlers {
+				if configuredHandler == registeredHandler {
+					slogHandlers = append(slogHandlers[:i], slogHandlers[i+1:]...)
+					break
+				}
+			}
+
+			if len(slogHandlers) > 0 {
+				slog.SetDefault(logger.New(slogHandlers...))
+				return
+			}
+			if slogBaseLogger != nil {
+				slog.SetDefault(slogBaseLogger)
+				slogBaseLogger = nil
+			}
+		})
+	}
 }
 
 func isDefaultSlogHandler(handler slog.Handler) bool {

--- a/workflows/v1/telemetry_test.go
+++ b/workflows/v1/telemetry_test.go
@@ -73,11 +73,30 @@ func TestConfigureConsoleLoggingIsIdempotent(t *testing.T) {
 	assert.Len(t, slogHandlers, 1)
 }
 
+func TestConfigureRemovableSlogHandlerStopsFanoutAndRestoresLogger(t *testing.T) {
+	resetSlogConfigurationForTest(t)
+
+	records := make([]string, 0)
+	baseLogger := slog.New(&recordingSlogHandler{name: "base", records: &records})
+	slog.SetDefault(baseLogger)
+	remove := configureRemovableSlogHandler(&recordingSlogHandler{name: "worker", records: &records})
+	slog.Info("before removal")
+	remove()
+	remove()
+	slog.Info("after removal")
+
+	assert.Equal(t, []string{
+		"base:before removal",
+		"worker:before removal",
+		"base:after removal",
+	}, records)
+}
+
 func TestWithSpanResultUsesTaskRunnerTracer(t *testing.T) {
 	spanRecorder := tracetest.NewSpanRecorder()
 	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
 	ctx := context.WithValue(context.Background(), contextKeyTaskExecution, &taskExecutionContext{
-		runner: &TaskRunner{tracer: tracerProvider.Tracer("test")},
+		executor: &taskExecutor{tracer: tracerProvider.Tracer("test")},
 	})
 
 	result, err := WithSpanResult(ctx, "expensive-compute", func(ctx context.Context) (string, error) {
@@ -111,7 +130,9 @@ func resetSlogConfigurationForTest(t *testing.T) {
 	slog.SetDefault(initialDefaultSlogLogger)
 	slogHandlersMu.Lock()
 	previousHandlers := slogHandlers
+	previousBaseLogger := slogBaseLogger
 	slogHandlers = nil
+	slogBaseLogger = nil
 	consoleLogHandlerOnce = sync.Once{}
 	slogHandlersMu.Unlock()
 
@@ -121,6 +142,7 @@ func resetSlogConfigurationForTest(t *testing.T) {
 		slogHandlersMu.Lock()
 		defer slogHandlersMu.Unlock()
 		slogHandlers = previousHandlers
+		slogBaseLogger = previousBaseLogger
 		consoleLogHandlerOnce = sync.Once{}
 	})
 }

--- a/workflows/v1/worker.go
+++ b/workflows/v1/worker.go
@@ -1,0 +1,476 @@
+package workflows
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tilebox/tilebox-go/internal/span"
+	obstracer "github.com/tilebox/tilebox-go/observability/tracer"
+	workflowsv1 "github.com/tilebox/tilebox-go/protogen/workflows/v1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+const (
+	workerAddressEnvironmentVariable = "TILEBOX_WORKER_ADDRESS"
+	workerShutdownGracePeriod        = 5 * time.Second
+	workerCleanupTimeout             = 5 * time.Second
+)
+
+type workerState uint8
+
+const (
+	workerStateNew workerState = iota
+	workerStateStarting
+	workerStateServing
+	workerStateInitialized
+	workerStateStopping
+	workerStateStopped
+)
+
+type workerRuntime struct {
+	executor *taskExecutor
+	cleanup  func(context.Context)
+}
+
+var errInvalidWorkerConfiguration = errors.New("invalid worker configuration")
+
+// Worker serves registered Go tasks as an execution-only child process managed by tilebox runner start.
+//
+// A Worker never polls for tasks, acquires or extends leases, or reports results to the Tilebox API. Its generated
+// WorkerService is served on the private Unix socket supplied in TILEBOX_WORKER_ADDRESS. The managing runner remains
+// responsible for polling, routing, lease management, and result reporting.
+//
+// Shutdown is graceful for up to five seconds. After that deadline, the active task context is canceled and the RPC
+// server is stopped. Task implementations must honor context cancellation; the managing runner may terminate a child
+// process that does not exit.
+type Worker struct {
+	workflowsv1.UnimplementedWorkerServiceServer
+
+	mu       sync.Mutex
+	state    workerState
+	registry *taskRegistry
+	server   *grpc.Server
+	runtime  *workerRuntime
+	init     *workflowsv1.InitializeRunnerRequest
+
+	stopRequested chan struct{}
+	executionSlot chan struct{}
+	activeCancel  context.CancelFunc
+	activeDone    chan struct{}
+
+	shutdownGracePeriod time.Duration
+	cleanupTimeout      time.Duration
+}
+
+var _ workflowsv1.WorkerServiceServer = (*Worker)(nil)
+
+// NewWorker creates an execution-only workflow worker.
+//
+// Construction only allocates in-memory lifecycle and task registration state. It does not create a client, perform
+// cluster lookup, access credentials, poll a queue, or make any network request.
+func NewWorker() *Worker {
+	executionSlot := make(chan struct{}, 1)
+	executionSlot <- struct{}{}
+	return &Worker{
+		state:               workerStateNew,
+		registry:            newTaskRegistry(),
+		stopRequested:       make(chan struct{}),
+		executionSlot:       executionSlot,
+		shutdownGracePeriod: workerShutdownGracePeriod,
+		cleanupTimeout:      workerCleanupTimeout,
+	}
+}
+
+// RegisterTasks makes the worker aware of tasks it can execute.
+//
+// Registration is concurrency-safe and uses the same identifier validation and duplicate checks as TaskRunner.
+// Registration is permanently frozen when Serve starts, including when startup subsequently fails.
+func (w *Worker) RegisterTasks(tasks ...ExecutableTask) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.state != workerStateNew {
+		return errors.New("cannot register tasks after worker serving has started")
+	}
+	return w.registry.registerTasks(tasks...)
+}
+
+// Serve binds TILEBOX_WORKER_ADDRESS, serves the generated WorkerService, and blocks until shutdown.
+//
+// Serve can be called once. It returns nil after context cancellation, a supported process signal, or a
+// ShutdownWorker RPC. The socket is removed before Serve returns. Concurrent or repeated calls return an error.
+func (w *Worker) Serve(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("worker serve context must not be nil")
+	}
+
+	w.mu.Lock()
+	if w.state != workerStateNew {
+		w.mu.Unlock()
+		return errors.New("worker can only be served once")
+	}
+	w.state = workerStateStarting
+	w.mu.Unlock()
+
+	listener, cleanupSocket, err := listenWorker(os.Getenv(workerAddressEnvironmentVariable))
+	if err != nil {
+		w.finishServe()
+		return fmt.Errorf("failed to start worker service: %w", err)
+	}
+
+	server := grpc.NewServer()
+	workflowsv1.RegisterWorkerServiceServer(server, w)
+
+	w.mu.Lock()
+	w.server = server
+	w.state = workerStateServing
+	w.mu.Unlock()
+
+	ctxSignal, stopSignals := signal.NotifyContext(ctx, runnerShutdownSignals()...)
+	defer stopSignals()
+
+	serveErrors := make(chan error, 1)
+	go func() {
+		serveErrors <- server.Serve(listener)
+	}()
+
+	select {
+	case err = <-serveErrors:
+		w.markStopping()
+		w.cancelActiveTask()
+		w.stopServer(server, 0)
+	case <-ctxSignal.Done():
+		w.markStopping()
+		w.cancelActiveTask()
+		w.stopServer(server, 0)
+		err = <-serveErrors
+	}
+
+	w.finishServe()
+	cleanupErr := cleanupSocket()
+	if err == nil || errors.Is(err, grpc.ErrServerStopped) || ctxSignal.Err() != nil {
+		if cleanupErr != nil {
+			return fmt.Errorf("failed to clean up worker socket: %w", cleanupErr)
+		}
+		return nil
+	}
+	return errors.Join(fmt.Errorf("worker service stopped unexpectedly: %w", err), cleanupErr)
+}
+
+// ListRegisteredTasks implements workflows.v1.WorkerService and is available before initialization.
+func (w *Worker) ListRegisteredTasks(context.Context, *emptypb.Empty) (*workflowsv1.TaskIdentifiers, error) {
+	return workflowsv1.TaskIdentifiers_builder{Identifiers: w.registry.identifiers()}.Build(), nil
+}
+
+// InitializeWorker implements workflows.v1.WorkerService initialization.
+//
+// A semantically identical repeated request is idempotent. Any conflicting request is rejected, and a failed
+// initialization may be retried. Request API connection fields are authoritative; initialization does not fall back
+// to TILEBOX_API_URL or TILEBOX_API_KEY.
+func (w *Worker) InitializeWorker(ctx context.Context, request *workflowsv1.InitializeRunnerRequest) (*workflowsv1.InitializeRunnerResponse, error) {
+	if request == nil {
+		return nil, status.Error(codes.InvalidArgument, "worker initialization request is required")
+	}
+	if err := request.GetRunnerId().CheckValid(); err != nil {
+		return nil, status.Error(codes.InvalidArgument, "worker initialization runner ID is invalid")
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	switch w.state {
+	case workerStateInitialized:
+		if equivalentWorkerInitialization(w.init, request) {
+			return &workflowsv1.InitializeRunnerResponse{}, nil
+		}
+		return nil, status.Error(codes.FailedPrecondition, "worker is already initialized with different configuration")
+	case workerStateServing:
+		// Continue below.
+	case workerStateStopping, workerStateStopped:
+		return nil, status.Error(codes.FailedPrecondition, "worker is shutting down")
+	case workerStateNew, workerStateStarting:
+		return nil, status.Error(codes.FailedPrecondition, "worker is not serving")
+	}
+
+	runtime, err := newWorkerRuntime(ctx, w.registry, request, otel.GetMeterProvider())
+	if err != nil {
+		if !errors.Is(err, errInvalidWorkerConfiguration) {
+			return nil, status.Error(codes.Internal, "worker initialization failed")
+		}
+		return nil, status.Error(codes.InvalidArgument, "worker initialization configuration is invalid")
+	}
+	w.runtime = runtime
+	w.init = proto.CloneOf(request)
+	w.state = workerStateInitialized
+	return &workflowsv1.InitializeRunnerResponse{}, nil
+}
+
+// ExecuteTask implements workflows.v1.WorkerService task execution.
+//
+// Calls are serialized because a release worker is managed by one routing runner. RPC cancellation is propagated to
+// the task context. Calls made before successful initialization or while shutting down return an infrastructure-class
+// failed task response rather than a transport error.
+func (w *Worker) ExecuteTask(ctx context.Context, task *workflowsv1.Task) (*workflowsv1.ExecuteTaskResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, status.FromContextError(ctx.Err()).Err()
+	case <-w.stopRequested:
+		return w.failedResponse(task, errors.New("worker is shutting down")), nil
+	case <-w.executionSlot:
+	}
+	defer func() { w.executionSlot <- struct{}{} }()
+
+	w.mu.Lock()
+	if w.state != workerStateInitialized || w.runtime == nil {
+		stopping := w.state == workerStateStopping || w.state == workerStateStopped
+		w.mu.Unlock()
+		if stopping {
+			return w.failedResponse(task, errors.New("worker is shutting down")), nil
+		}
+		return w.failedResponse(task, errors.New("worker is not initialized")), nil
+	}
+
+	runtime := w.runtime
+	if task.GetJob() == nil {
+		w.mu.Unlock()
+		return w.failedResponse(task, errors.New("task has no job")), nil
+	}
+	executionContext, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	w.activeCancel = cancel
+	w.activeDone = done
+	w.mu.Unlock()
+
+	response, err := runtime.executor.ExecuteTask(executionContext, task)
+	cancel()
+	close(done)
+
+	w.mu.Lock()
+	if w.activeDone == done {
+		w.activeCancel = nil
+		w.activeDone = nil
+	}
+	w.mu.Unlock()
+	return response, err
+}
+
+// ShutdownWorker implements workflows.v1.WorkerService graceful shutdown.
+//
+// Server shutdown runs asynchronously so this RPC can return before GracefulStop waits for its own handler.
+func (w *Worker) ShutdownWorker(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
+	w.mu.Lock()
+	switch w.state {
+	case workerStateStopping, workerStateStopped:
+		w.mu.Unlock()
+		return &emptypb.Empty{}, nil
+	case workerStateServing, workerStateInitialized:
+		w.state = workerStateStopping
+		close(w.stopRequested)
+		server := w.server
+		gracePeriod := w.shutdownGracePeriod
+		w.mu.Unlock()
+		go w.stopServer(server, gracePeriod)
+		return &emptypb.Empty{}, nil
+	case workerStateNew, workerStateStarting:
+		w.mu.Unlock()
+		return nil, status.Error(codes.FailedPrecondition, "worker is not serving")
+	}
+	w.mu.Unlock()
+	return nil, status.Error(codes.Internal, "worker has invalid lifecycle state")
+}
+
+func (w *Worker) markStopping() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.state != workerStateStopping && w.state != workerStateStopped {
+		w.state = workerStateStopping
+		close(w.stopRequested)
+	}
+}
+
+func (w *Worker) cancelActiveTask() {
+	w.mu.Lock()
+	cancel := w.activeCancel
+	w.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (w *Worker) stopServer(server *grpc.Server, gracePeriod time.Duration) {
+	if server == nil {
+		return
+	}
+
+	if gracePeriod <= 0 {
+		w.cancelActiveTask()
+		server.Stop()
+		return
+	}
+
+	gracefulStopDone := make(chan struct{})
+	go func() {
+		server.GracefulStop()
+		close(gracefulStopDone)
+	}()
+
+	timer := time.NewTimer(gracePeriod)
+	defer timer.Stop()
+	select {
+	case <-gracefulStopDone:
+		return
+	case <-timer.C:
+		w.cancelActiveTask()
+		server.Stop()
+	}
+}
+
+func (w *Worker) finishServe() {
+	w.mu.Lock()
+	runtime := w.runtime
+	w.runtime = nil
+	w.init = nil
+	w.server = nil
+	w.state = workerStateStopped
+	cleanupTimeout := w.cleanupTimeout
+	w.mu.Unlock()
+
+	if runtime != nil {
+		cleanupContext, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+		runtime.cleanup(cleanupContext)
+		cancel()
+	}
+}
+
+func newWorkerRuntime(ctx context.Context, registry *taskRegistry, request *workflowsv1.InitializeRunnerRequest, meterProvider metric.MeterProvider) (*workerRuntime, error) {
+	apiURL := defaultTileboxAPIURL
+	apiToken := ""
+	if connection := request.GetApiConnection(); connection != nil {
+		if strings.TrimSpace(connection.GetUrl()) != "" {
+			apiURL = connection.GetUrl()
+		}
+		apiToken = connection.GetToken()
+	}
+
+	cfg := newClientConfig([]ClientOption{WithURL(apiURL), WithAPIKey(apiToken)})
+	cleanupFunctions := make([]func(context.Context), 0, 3)
+
+	if apiToken != "" && isHTTPURL(apiURL) {
+		traceEndpoint, ok := otlpEndpointURL(apiURL, otlpTracesPath)
+		if !ok {
+			return nil, fmt.Errorf("%w: API URL", errInvalidWorkerConfiguration)
+		}
+		tracerProvider, cleanupTracing, err := obstracer.NewOtelProvider(ctx, tileboxTelemetryService,
+			obstracer.WithEndpointURL(traceEndpoint),
+			obstracer.WithHeaders(tileboxTelemetryHeaders(apiToken)),
+		)
+		if err != nil {
+			return nil, errors.New("failed to configure worker tracing")
+		}
+		cfg.tracerProvider = tracerProvider
+		cleanupFunctions = append(cleanupFunctions, cleanupTracing)
+
+		logHandler, cleanupLogging, err := NewTileboxLogHandler(ctx, apiURL, apiToken, slog.LevelInfo)
+		if err != nil {
+			cleanupTracing(ctx)
+			return nil, errors.New("failed to configure worker logging")
+		}
+		removeLogHandler := configureRemovableSlogHandler(logHandler)
+		cleanupFunctions = append(cleanupFunctions, cleanupLogging)
+		cleanupFunctions = append(cleanupFunctions, func(context.Context) { removeLogHandler() })
+	}
+
+	if closeIdleConnections, ok := cfg.httpClient.(interface{ CloseIdleConnections() }); ok {
+		cleanupFunctions = append(cleanupFunctions, func(context.Context) { closeIdleConnections.CloseIdleConnections() })
+	}
+
+	client := newClient(cfg)
+	logger := workerLogger(request)
+	executor, err := newTaskExecutor(registry, request.GetCluster().GetSlug(), client, cfg.tracerProvider.Tracer(otelTracerName), logger, meterProvider)
+	if err != nil {
+		for _, cleanup := range slices.Backward(cleanupFunctions) {
+			cleanup(ctx)
+		}
+		return nil, err
+	}
+	executor.redactError, executor.redactString = secretRedactors(apiToken, os.Getenv("TILEBOX_API_KEY"))
+
+	logger.DebugContext(span.ContextWithTraceParent(ctx, request.GetTraceParent()), "worker initialized")
+	return &workerRuntime{
+		executor: executor,
+		cleanup: func(ctx context.Context) {
+			for _, cleanup := range slices.Backward(cleanupFunctions) {
+				cleanup(ctx)
+			}
+		},
+	}, nil
+}
+
+func workerLogger(request *workflowsv1.InitializeRunnerRequest) *slog.Logger {
+	attributes := []any{
+		slog.String("runner_id", request.GetRunnerId().AsUUID().String()),
+		slog.String("cluster", request.GetCluster().GetSlug()),
+		slog.String("workflow", request.GetWorkflow().GetSlug()),
+	}
+	if releases := request.GetWorkflow().GetReleases(); len(releases) > 0 {
+		attributes = append(attributes, slog.String("release_id", releases[0].GetId().AsUUID().String()))
+	}
+	return slog.Default().With(attributes...)
+}
+
+func secretRedactors(secrets ...string) (func(error) error, func(string) string) {
+	redactString := func(message string) string {
+		for _, secret := range secrets {
+			if secret != "" {
+				message = strings.ReplaceAll(message, secret, "[REDACTED]")
+			}
+		}
+		return message
+	}
+	redactError := func(err error) error {
+		if err == nil {
+			return nil
+		}
+		return errors.New(redactString(err.Error()))
+	}
+	return redactError, redactString
+}
+
+func equivalentWorkerInitialization(first, second *workflowsv1.InitializeRunnerRequest) bool {
+	first = proto.CloneOf(first)
+	second = proto.CloneOf(second)
+	first.ClearTraceParent()
+	second.ClearTraceParent()
+	return proto.Equal(first, second)
+}
+
+func (w *Worker) failedResponse(task *workflowsv1.Task, err error) *workflowsv1.ExecuteTaskResponse {
+	w.mu.Lock()
+	runtime := w.runtime
+	w.mu.Unlock()
+
+	redactError, redactString := secretRedactors(os.Getenv("TILEBOX_API_KEY"))
+	if runtime != nil {
+		redactError = runtime.executor.redactError
+		redactString = runtime.executor.redactString
+	}
+	err = redactError(err)
+	return workflowsv1.ExecuteTaskResponse_builder{FailedTask: workflowsv1.TaskFailedRequest_builder{
+		TaskId:           task.GetId(),
+		Display:          failedTaskDisplay(redactString(task.GetDisplay()), err),
+		WasWorkflowError: false,
+	}.Build()}.Build()
+}

--- a/workflows/v1/worker_other.go
+++ b/workflows/v1/worker_other.go
@@ -1,0 +1,12 @@
+//go:build !unix
+
+package workflows
+
+import (
+	"errors"
+	"net"
+)
+
+func listenWorker(string) (net.Listener, func() error, error) {
+	return nil, nil, errors.New("execution-only workflow workers require Unix domain socket support")
+}

--- a/workflows/v1/worker_test.go
+++ b/workflows/v1/worker_test.go
@@ -1,0 +1,924 @@
+//go:build unix
+
+package workflows
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	examplesv1 "github.com/tilebox/tilebox-go/protogen/examples/v1"
+	tileboxv1 "github.com/tilebox/tilebox-go/protogen/tilebox/v1"
+	workflowsv1 "github.com/tilebox/tilebox-go/protogen/workflows/v1"
+	"github.com/tilebox/tilebox-go/protogen/workflows/v1/workflowsv1connect"
+	"go.opentelemetry.io/otel/trace/noop"
+	"golang.org/x/net/http2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type workerRegistrationTask struct{}
+
+func (*workerRegistrationTask) Execute(context.Context) error { return nil }
+
+type workerInvalidIdentifierTask struct{}
+
+func (*workerInvalidIdentifierTask) Execute(context.Context) error { return nil }
+func (*workerInvalidIdentifierTask) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("", "not-a-version")
+}
+
+type workerNilIdentifierTask struct{}
+
+func (*workerNilIdentifierTask) Execute(context.Context) error { return nil }
+func (*workerNilIdentifierTask) Identifier() TaskIdentifier    { return nil }
+
+type workerValueTask struct{}
+
+func (workerValueTask) Execute(context.Context) error { return nil }
+
+var workerJSONValues chan string
+
+type workerJSONTask struct {
+	Value string `json:"value"`
+}
+
+func (*workerJSONTask) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/json", "v1.0")
+}
+
+func (task *workerJSONTask) Execute(context.Context) error {
+	workerJSONValues <- task.Value
+	return nil
+}
+
+var workerProtoValues chan int64
+
+type workerProtoTask struct {
+	examplesv1.SpawnWorkflowTreeTask
+}
+
+func (*workerProtoTask) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/protobuf", "v1.0")
+}
+
+func (task *workerProtoTask) Execute(context.Context) error {
+	workerProtoValues <- task.GetDepth()
+	return nil
+}
+
+type workerDispatchV1Task struct{}
+
+func (*workerDispatchV1Task) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/dispatch", "v1.0")
+}
+func (*workerDispatchV1Task) Execute(context.Context) error { return nil }
+
+type workerDispatchV2Task struct{}
+
+func (*workerDispatchV2Task) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/dispatch", "v2.0")
+}
+func (*workerDispatchV2Task) Execute(context.Context) error { return nil }
+
+type workerChildTask struct {
+	Value string `json:"value"`
+}
+
+func (*workerChildTask) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/child", "v1.0")
+}
+
+type workerTaskContextResult struct {
+	cluster   string
+	hasClient bool
+	err       error
+}
+
+var workerTaskContextResults chan workerTaskContextResult
+
+type workerContextTask struct{}
+
+func (*workerContextTask) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/context", "v1.0")
+}
+
+func (*workerContextTask) Execute(ctx context.Context) error {
+	client, clientErr := GetClient(ctx)
+	cluster, clusterErr := GetCurrentCluster(ctx)
+	if clientErr == nil && clusterErr == nil {
+		progress := Progress("work")
+		if err := progress.Add(ctx, 3); err != nil {
+			clientErr = err
+		} else if err := progress.Done(ctx, 2); err != nil {
+			clientErr = err
+		} else if _, err := SubmitSubtask(ctx, &workerChildTask{Value: "child"}); err != nil {
+			clientErr = err
+		} else if err := SetTaskDisplay(ctx, "context ready"); err != nil {
+			clientErr = err
+		}
+	}
+	workerTaskContextResults <- workerTaskContextResult{
+		cluster:   cluster,
+		hasClient: client != nil,
+		err:       errors.Join(clientErr, clusterErr),
+	}
+	return errors.Join(clientErr, clusterErr)
+}
+
+type workerUserErrorTask struct{}
+
+func (*workerUserErrorTask) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/user-error", "v1.0")
+}
+
+func (*workerUserErrorTask) Execute(ctx context.Context) error {
+	if err := Progress("before-error").Add(ctx, 5); err != nil {
+		return err
+	}
+	return errors.New("user task failed")
+}
+
+type workerPanicTask struct{}
+
+func (*workerPanicTask) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/panic", "v1.0")
+}
+
+func (*workerPanicTask) Execute(context.Context) error { panic("user panic") }
+
+var (
+	workerCancellationStarted  chan struct{}
+	workerCancellationObserved chan error
+)
+
+type workerCancellationTask struct{}
+
+func (*workerCancellationTask) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/cancellation", "v1.0")
+}
+
+func (*workerCancellationTask) Execute(ctx context.Context) error {
+	close(workerCancellationStarted)
+	<-ctx.Done()
+	workerCancellationObserved <- ctx.Err()
+	return ctx.Err()
+}
+
+var (
+	workerGracefulStarted chan struct{}
+	workerGracefulRelease chan struct{}
+)
+
+type workerGracefulTask struct{}
+
+func (*workerGracefulTask) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/graceful", "v1.0")
+}
+
+func (*workerGracefulTask) Execute(context.Context) error {
+	close(workerGracefulStarted)
+	<-workerGracefulRelease
+	return nil
+}
+
+var (
+	workerQueuedStarted       chan struct{}
+	workerQueuedCanceled      chan struct{}
+	workerQueuedSecondRan     atomic.Bool
+	workerQueuedSecondStarted chan struct{}
+)
+
+type workerQueuedFirstTask struct{}
+
+func (*workerQueuedFirstTask) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/queued-first", "v1.0")
+}
+
+func (*workerQueuedFirstTask) Execute(ctx context.Context) error {
+	close(workerQueuedStarted)
+	<-ctx.Done()
+	close(workerQueuedCanceled)
+	return ctx.Err()
+}
+
+type workerQueuedSecondTask struct{}
+
+func (*workerQueuedSecondTask) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/queued-second", "v1.0")
+}
+
+func (*workerQueuedSecondTask) Execute(context.Context) error {
+	workerQueuedSecondRan.Store(true)
+	return nil
+}
+
+var workerSensitiveValue string
+
+type workerSensitiveTask struct{}
+
+func (*workerSensitiveTask) Identifier() TaskIdentifier {
+	return NewTaskIdentifier("tilebox.com/tests/sensitive", "v1.0")
+}
+
+func (*workerSensitiveTask) Execute(ctx context.Context) error {
+	if err := SetTaskDisplay(ctx, "credential "+workerSensitiveValue); err != nil {
+		return err
+	}
+	return errors.New("credential failure: " + workerSensitiveValue)
+}
+
+type testWorkerServer struct {
+	client     workflowsv1.WorkerServiceClient
+	connection *grpc.ClientConn
+	socketPath string
+	cancel     context.CancelFunc
+	done       chan struct{}
+
+	errMu sync.Mutex
+	err   error
+}
+
+func startTestWorker(t *testing.T, worker *Worker) *testWorkerServer {
+	t.Helper()
+	return startTestWorkerAt(t, worker, filepath.Join(t.TempDir(), "worker.sock"))
+}
+
+func startTestWorkerAt(t *testing.T, worker *Worker, socketPath string) *testWorkerServer {
+	t.Helper()
+	t.Setenv(workerAddressEnvironmentVariable, "unix://"+socketPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	server := &testWorkerServer{socketPath: socketPath, cancel: cancel, done: make(chan struct{})}
+	go func() {
+		err := worker.Serve(ctx)
+		server.errMu.Lock()
+		server.err = err
+		server.errMu.Unlock()
+		close(server.done)
+	}()
+
+	connection, err := grpc.NewClient(
+		"passthrough:///tilebox-worker",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+		}),
+	)
+	require.NoError(t, err)
+	server.connection = connection
+	server.client = workflowsv1.NewWorkerServiceClient(connection)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		ctx, cancelList := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		_, listErr := server.client.ListRegisteredTasks(ctx, &emptypb.Empty{})
+		cancelList()
+		if listErr == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			require.NoError(t, listErr, "worker never became ready")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	info, err := os.Lstat(socketPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	t.Cleanup(func() {
+		_ = connection.Close()
+		cancel()
+		select {
+		case <-server.done:
+		case <-time.After(3 * time.Second):
+			t.Errorf("worker did not stop during test cleanup")
+		}
+	})
+	return server
+}
+
+func (s *testWorkerServer) wait(t *testing.T) error {
+	t.Helper()
+	select {
+	case <-s.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker Serve did not return")
+	}
+	s.errMu.Lock()
+	defer s.errMu.Unlock()
+	return s.err
+}
+
+func testWorkerInitializationRequest() *workflowsv1.InitializeRunnerRequest {
+	apiURL := filepath.Join(os.TempDir(), "tilebox-worker-test-api.sock")
+	apiToken := ""
+	traceParent := "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	return workflowsv1.InitializeRunnerRequest_builder{
+		RunnerId:    tileboxv1.NewUUID(uuid.New()),
+		TraceParent: &traceParent,
+		Cluster: workflowsv1.Cluster_builder{
+			Slug:        "test-cluster",
+			DisplayName: "Test Cluster",
+		}.Build(),
+		Workflow: workflowsv1.Workflow_builder{
+			Slug: "test-workflow",
+			Name: "Test Workflow",
+			Releases: []*workflowsv1.WorkflowRelease{
+				workflowsv1.WorkflowRelease_builder{Id: tileboxv1.NewUUID(uuid.New())}.Build(),
+			},
+		}.Build(),
+		ApiConnection: workflowsv1.TileboxAPIConnection_builder{
+			Url:   &apiURL,
+			Token: &apiToken,
+		}.Build(),
+	}.Build()
+}
+
+func testWorkerTask(identifier TaskIdentifier, input []byte) *workflowsv1.Task {
+	return workflowsv1.Task_builder{
+		Id: tileboxv1.NewUUID(uuid.New()),
+		Identifier: workflowsv1.TaskIdentifier_builder{
+			Name:    identifier.Name(),
+			Version: identifier.Version(),
+		}.Build(),
+		State:   workflowsv1.TaskState_TASK_STATE_RUNNING,
+		Input:   input,
+		Display: proto.String(identifier.Display()),
+		Job: workflowsv1.Job_builder{
+			Id:          tileboxv1.NewUUID(uuid.New()),
+			Name:        "worker test job",
+			TraceParent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+		}.Build(),
+	}.Build()
+}
+
+func initializeTestWorker(t *testing.T, server *testWorkerServer) {
+	t.Helper()
+	request := testWorkerInitializationRequest()
+	_, err := server.client.InitializeWorker(context.Background(), request)
+	require.NoError(t, err)
+}
+
+func TestWorkerRegistrationAndListBeforeInitialization(t *testing.T) {
+	t.Setenv("TILEBOX_API_URL", "https://network-must-not-be-used.invalid")
+	t.Setenv("TILEBOX_API_KEY", "construction-must-not-read-this-credential")
+
+	worker := NewWorker()
+	require.NoError(t, worker.RegisterTasks(&workerRegistrationTask{}, &workerJSONTask{}))
+	require.ErrorContains(t, worker.RegisterTasks(&workerRegistrationTask{}), "duplicate task identifier")
+	require.ErrorContains(t, worker.RegisterTasks(&workerInvalidIdentifierTask{}), "task name is empty")
+	require.ErrorContains(t, worker.RegisterTasks(&workerNilIdentifierTask{}), "task identifier is nil")
+	require.ErrorContains(t, worker.RegisterTasks(workerValueTask{}), "must be a non-nil pointer to a struct")
+	var nilTask *workerRegistrationTask
+	require.ErrorContains(t, worker.RegisterTasks(nilTask), "must be a non-nil pointer to a struct")
+
+	server := startTestWorker(t, worker)
+	response, err := server.client.ListRegisteredTasks(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+	require.Len(t, response.GetIdentifiers(), 2)
+	assert.Equal(t, "workerRegistrationTask", response.GetIdentifiers()[0].GetName())
+	assert.Equal(t, "v0.0", response.GetIdentifiers()[0].GetVersion())
+	assert.Equal(t, "tilebox.com/tests/json", response.GetIdentifiers()[1].GetName())
+	require.ErrorContains(t, worker.RegisterTasks(&workerPanicTask{}), "after worker serving has started")
+}
+
+func TestWorkerConnectGRPCInteroperability(t *testing.T) {
+	workerJSONValues = make(chan string, 1)
+	worker := NewWorker()
+	require.NoError(t, worker.RegisterTasks(&workerJSONTask{}))
+	server := startTestWorker(t, worker)
+
+	transport := &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, _, _ string, _ *tls.Config) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", server.socketPath)
+		},
+	}
+	t.Cleanup(transport.CloseIdleConnections)
+	client := workflowsv1connect.NewWorkerServiceClient(
+		&http.Client{Transport: transport},
+		"http://tilebox-worker",
+		connect.WithGRPC(),
+	)
+
+	registered, err := client.ListRegisteredTasks(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+	require.Len(t, registered.Msg.GetIdentifiers(), 1)
+	assert.Equal(t, (&workerJSONTask{}).Identifier().Name(), registered.Msg.GetIdentifiers()[0].GetName())
+
+	_, err = client.InitializeWorker(context.Background(), connect.NewRequest(testWorkerInitializationRequest()))
+	require.NoError(t, err)
+	input, err := json.Marshal(&workerJSONTask{Value: "connect gRPC decoded"})
+	require.NoError(t, err)
+	executed, err := client.ExecuteTask(context.Background(), connect.NewRequest(testWorkerTask((&workerJSONTask{}).Identifier(), input)))
+	require.NoError(t, err)
+	require.NotNil(t, executed.Msg.GetComputedTask())
+	assert.Equal(t, "connect gRPC decoded", <-workerJSONValues)
+
+	_, err = client.ShutdownWorker(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+	require.NoError(t, server.wait(t))
+}
+
+func TestWorkerConcurrentRegistrationAndServeLifecycle(t *testing.T) {
+	worker := NewWorker()
+	socketPath := filepath.Join(t.TempDir(), "worker.sock")
+	t.Setenv(workerAddressEnvironmentVariable, "unix://"+socketPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	start := make(chan struct{})
+	errorsCh := make(chan error, 33)
+	for range 32 {
+		go func() {
+			<-start
+			errorsCh <- worker.RegisterTasks()
+		}()
+	}
+	serveDone := make(chan error, 1)
+	go func() {
+		<-start
+		serveDone <- worker.Serve(ctx)
+	}()
+	close(start)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Lstat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("worker did not bind socket")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	require.ErrorContains(t, worker.Serve(context.Background()), "only be served once")
+	for range 32 {
+		err := <-errorsCh
+		if err != nil {
+			require.ErrorContains(t, err, "after worker serving has started")
+		}
+	}
+	cancel()
+	require.NoError(t, <-serveDone)
+	_, err := os.Lstat(socketPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.ErrorContains(t, worker.RegisterTasks(), "after worker serving has started")
+}
+
+func TestWorkerProtocolInitializationAndExecution(t *testing.T) {
+	workerJSONValues = make(chan string, 1)
+	workerProtoValues = make(chan int64, 1)
+	workerTaskContextResults = make(chan workerTaskContextResult, 1)
+
+	worker := NewWorker()
+	require.NoError(t, worker.RegisterTasks(
+		&workerJSONTask{},
+		&workerProtoTask{},
+		&workerDispatchV1Task{},
+		&workerDispatchV2Task{},
+		&workerContextTask{},
+	))
+	server := startTestWorker(t, worker)
+
+	preInitializeTask := testWorkerTask((&workerJSONTask{}).Identifier(), []byte(`{"value":"before"}`))
+	response, err := server.client.ExecuteTask(context.Background(), preInitializeTask)
+	require.NoError(t, err)
+	require.NotNil(t, response.GetFailedTask())
+	assert.False(t, response.GetFailedTask().GetWasWorkflowError())
+	assert.Contains(t, response.GetFailedTask().GetDisplay(), "worker is not initialized")
+
+	initialization := testWorkerInitializationRequest()
+	const concurrentInitializations = 12
+	errorsCh := make(chan error, concurrentInitializations)
+	for range concurrentInitializations {
+		go func() {
+			_, err := server.client.InitializeWorker(context.Background(), proto.CloneOf(initialization))
+			errorsCh <- err
+		}()
+	}
+	for range concurrentInitializations {
+		require.NoError(t, <-errorsCh)
+	}
+	retriedTraceParent := proto.CloneOf(initialization)
+	retriedTraceParent.SetTraceParent("00-11111111111111111111111111111111-2222222222222222-01")
+	_, err = server.client.InitializeWorker(context.Background(), retriedTraceParent)
+	require.NoError(t, err)
+
+	conflicting := proto.CloneOf(initialization)
+	conflicting.SetCluster(workflowsv1.Cluster_builder{Slug: "other-cluster"}.Build())
+	_, err = server.client.InitializeWorker(context.Background(), conflicting)
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+	jsonInput, err := json.Marshal(&workerJSONTask{Value: "json decoded"})
+	require.NoError(t, err)
+	response, err = server.client.ExecuteTask(context.Background(), testWorkerTask((&workerJSONTask{}).Identifier(), jsonInput))
+	require.NoError(t, err)
+	require.NotNil(t, response.GetComputedTask())
+	assert.Equal(t, "json decoded", <-workerJSONValues)
+
+	protoInput, err := proto.Marshal(&workerProtoTask{SpawnWorkflowTreeTask: *examplesv1.SpawnWorkflowTreeTask_builder{
+		Depth: proto.Int64(7),
+	}.Build()})
+	require.NoError(t, err)
+	response, err = server.client.ExecuteTask(context.Background(), testWorkerTask((&workerProtoTask{}).Identifier(), protoInput))
+	require.NoError(t, err)
+	require.NotNil(t, response.GetComputedTask())
+	assert.Equal(t, int64(7), <-workerProtoValues)
+
+	for _, identifier := range []TaskIdentifier{(&workerDispatchV1Task{}).Identifier(), (&workerDispatchV2Task{}).Identifier()} {
+		response, err = server.client.ExecuteTask(context.Background(), testWorkerTask(identifier, []byte(`{}`)))
+		require.NoError(t, err)
+		require.NotNil(t, response.GetComputedTask())
+	}
+
+	response, err = server.client.ExecuteTask(context.Background(), testWorkerTask((&workerContextTask{}).Identifier(), []byte(`{}`)))
+	require.NoError(t, err)
+	require.NotNil(t, response.GetComputedTask())
+	contextResult := <-workerTaskContextResults
+	require.NoError(t, contextResult.err)
+	assert.True(t, contextResult.hasClient)
+	assert.Equal(t, "test-cluster", contextResult.cluster)
+	assert.Equal(t, "context ready", response.GetComputedTask().GetDisplay())
+	require.Len(t, response.GetComputedTask().GetProgressUpdates(), 1)
+	assert.Equal(t, "work", response.GetComputedTask().GetProgressUpdates()[0].GetLabel())
+	assert.Equal(t, uint64(3), response.GetComputedTask().GetProgressUpdates()[0].GetTotal())
+	assert.Equal(t, uint64(2), response.GetComputedTask().GetProgressUpdates()[0].GetDone())
+	require.NotNil(t, response.GetComputedTask().GetSubTasks())
+	require.Len(t, response.GetComputedTask().GetSubTasks().GetTaskGroups(), 1)
+}
+
+func TestWorkerExecutionFailureClassification(t *testing.T) {
+	worker := NewWorker()
+	require.NoError(t, worker.RegisterTasks(&workerJSONTask{}, &workerUserErrorTask{}, &workerPanicTask{}))
+	server := startTestWorker(t, worker)
+	initializeTestWorker(t, server)
+
+	tests := []struct {
+		name             string
+		task             *workflowsv1.Task
+		wasWorkflowError bool
+		displayContains  string
+		progressUpdates  int
+	}{
+		{
+			name:             "unknown exact version",
+			task:             testWorkerTask(NewTaskIdentifier("tilebox.com/tests/json", "v9.0"), []byte(`{}`)),
+			wasWorkflowError: false,
+			displayContains:  "is not registered",
+		},
+		{
+			name:             "JSON decode",
+			task:             testWorkerTask((&workerJSONTask{}).Identifier(), []byte(`{"value":`)),
+			wasWorkflowError: true,
+			displayContains:  "failed to unmarshal json task",
+		},
+		{
+			name:             "user error",
+			task:             testWorkerTask((&workerUserErrorTask{}).Identifier(), []byte(`{}`)),
+			wasWorkflowError: true,
+			displayContains:  "user task failed",
+			progressUpdates:  1,
+		},
+		{
+			name:             "panic recovery",
+			task:             testWorkerTask((&workerPanicTask{}).Identifier(), []byte(`{}`)),
+			wasWorkflowError: true,
+			displayContains:  "task panicked: user panic",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := server.client.ExecuteTask(context.Background(), test.task)
+			require.NoError(t, err)
+			failedTask := response.GetFailedTask()
+			require.NotNil(t, failedTask)
+			assert.Equal(t, test.wasWorkflowError, failedTask.GetWasWorkflowError())
+			assert.Contains(t, failedTask.GetDisplay(), test.displayContains)
+			assert.Len(t, failedTask.GetProgressUpdates(), test.progressUpdates)
+		})
+	}
+}
+
+func TestWorkerExecuteCancellationReachesTaskContext(t *testing.T) {
+	workerCancellationStarted = make(chan struct{})
+	workerCancellationObserved = make(chan error, 1)
+	worker := NewWorker()
+	require.NoError(t, worker.RegisterTasks(&workerCancellationTask{}))
+	server := startTestWorker(t, worker)
+	initializeTestWorker(t, server)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	executeDone := make(chan error, 1)
+	go func() {
+		_, err := server.client.ExecuteTask(ctx, testWorkerTask((&workerCancellationTask{}).Identifier(), []byte(`{}`)))
+		executeDone <- err
+	}()
+	select {
+	case <-workerCancellationStarted:
+	case <-time.After(time.Second):
+		t.Fatal("task did not start")
+	}
+	cancel()
+
+	err := <-executeDone
+	require.Error(t, err)
+	assert.Equal(t, codes.Canceled, status.Code(err))
+	select {
+	case observed := <-workerCancellationObserved:
+		require.ErrorIs(t, observed, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("task did not observe RPC cancellation")
+	}
+}
+
+func TestWorkerShutdownIdleCleansUp(t *testing.T) {
+	worker := NewWorker()
+	server := startTestWorker(t, worker)
+	initializeTestWorker(t, server)
+
+	var cleanupCalls atomic.Int64
+	worker.mu.Lock()
+	originalCleanup := worker.runtime.cleanup
+	worker.runtime.cleanup = func(ctx context.Context) {
+		cleanupCalls.Add(1)
+		originalCleanup(ctx)
+	}
+	worker.mu.Unlock()
+
+	_, err := server.client.ShutdownWorker(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+	require.NoError(t, server.wait(t))
+	assert.Equal(t, int64(1), cleanupCalls.Load())
+	_, err = os.Lstat(server.socketPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestWorkerShutdownActiveIsBoundedAndCancelsTask(t *testing.T) {
+	workerCancellationStarted = make(chan struct{})
+	workerCancellationObserved = make(chan error, 1)
+	worker := NewWorker()
+	worker.shutdownGracePeriod = 25 * time.Millisecond
+	require.NoError(t, worker.RegisterTasks(&workerCancellationTask{}))
+	server := startTestWorker(t, worker)
+	initializeTestWorker(t, server)
+
+	executeDone := make(chan error, 1)
+	go func() {
+		_, err := server.client.ExecuteTask(context.Background(), testWorkerTask((&workerCancellationTask{}).Identifier(), []byte(`{}`)))
+		executeDone <- err
+	}()
+	select {
+	case <-workerCancellationStarted:
+	case <-time.After(time.Second):
+		t.Fatal("task did not start")
+	}
+
+	startedShutdown := time.Now()
+	_, err := server.client.ShutdownWorker(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+	require.NoError(t, server.wait(t))
+	assert.Less(t, time.Since(startedShutdown), time.Second)
+	select {
+	case observed := <-workerCancellationObserved:
+		require.ErrorIs(t, observed, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("active task did not observe shutdown cancellation")
+	}
+	require.Error(t, <-executeDone)
+	_, err = os.Lstat(server.socketPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestWorkerShutdownGracefullyDeliversActiveResult(t *testing.T) {
+	workerGracefulStarted = make(chan struct{})
+	workerGracefulRelease = make(chan struct{})
+	worker := NewWorker()
+	worker.shutdownGracePeriod = time.Second
+	require.NoError(t, worker.RegisterTasks(&workerGracefulTask{}))
+	server := startTestWorker(t, worker)
+	initializeTestWorker(t, server)
+
+	type executeResult struct {
+		response *workflowsv1.ExecuteTaskResponse
+		err      error
+	}
+	executeDone := make(chan executeResult, 1)
+	go func() {
+		response, err := server.client.ExecuteTask(context.Background(), testWorkerTask((&workerGracefulTask{}).Identifier(), []byte(`{}`)))
+		executeDone <- executeResult{response: response, err: err}
+	}()
+	select {
+	case <-workerGracefulStarted:
+	case <-time.After(time.Second):
+		t.Fatal("task did not start")
+	}
+
+	_, err := server.client.ShutdownWorker(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+	close(workerGracefulRelease)
+	result := <-executeDone
+	require.NoError(t, result.err)
+	require.NotNil(t, result.response.GetComputedTask())
+	require.NoError(t, server.wait(t))
+}
+
+func TestWorkerShutdownRejectsQueuedExecution(t *testing.T) {
+	workerQueuedStarted = make(chan struct{})
+	workerQueuedCanceled = make(chan struct{})
+	workerQueuedSecondStarted = make(chan struct{})
+	workerQueuedSecondRan.Store(false)
+	worker := NewWorker()
+	worker.shutdownGracePeriod = 25 * time.Millisecond
+	require.NoError(t, worker.RegisterTasks(&workerQueuedFirstTask{}, &workerQueuedSecondTask{}))
+	server := startTestWorker(t, worker)
+	initializeTestWorker(t, server)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := server.client.ExecuteTask(context.Background(), testWorkerTask((&workerQueuedFirstTask{}).Identifier(), []byte(`{}`)))
+		firstDone <- err
+	}()
+	select {
+	case <-workerQueuedStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first task did not start")
+	}
+
+	type executeResult struct {
+		response *workflowsv1.ExecuteTaskResponse
+		err      error
+	}
+	secondDone := make(chan executeResult, 1)
+	go func() {
+		close(workerQueuedSecondStarted)
+		response, err := server.client.ExecuteTask(context.Background(), testWorkerTask((&workerQueuedSecondTask{}).Identifier(), []byte(`{}`)))
+		secondDone <- executeResult{response: response, err: err}
+	}()
+	<-workerQueuedSecondStarted
+	time.Sleep(5 * time.Millisecond)
+
+	_, err := server.client.ShutdownWorker(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+	second := <-secondDone
+	require.NoError(t, second.err)
+	require.NotNil(t, second.response.GetFailedTask())
+	assert.False(t, second.response.GetFailedTask().GetWasWorkflowError())
+	assert.Contains(t, second.response.GetFailedTask().GetDisplay(), "worker is shutting down")
+	assert.False(t, workerQueuedSecondRan.Load())
+	select {
+	case <-workerQueuedCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("first task did not observe shutdown cancellation")
+	}
+	require.Error(t, <-firstDone)
+	require.NoError(t, server.wait(t))
+}
+
+func TestWorkerInitializationCanRetryAfterInvalidConfiguration(t *testing.T) {
+	worker := NewWorker()
+	server := startTestWorker(t, worker)
+	invalid := testWorkerInitializationRequest()
+	invalidURL := "http://"
+	token := "not-exported"
+	invalid.SetApiConnection(workflowsv1.TileboxAPIConnection_builder{Url: &invalidURL, Token: &token}.Build())
+
+	_, err := server.client.InitializeWorker(context.Background(), invalid)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.NotContains(t, err.Error(), token)
+
+	valid := testWorkerInitializationRequest()
+	valid.SetRunnerId(invalid.GetRunnerId())
+	_, err = server.client.InitializeWorker(context.Background(), valid)
+	require.NoError(t, err)
+}
+
+func TestWorkerParentCancellationAndListenFailures(t *testing.T) {
+	t.Run("parent cancellation", func(t *testing.T) {
+		worker := NewWorker()
+		server := startTestWorker(t, worker)
+		server.cancel()
+		require.NoError(t, server.wait(t))
+		_, err := os.Lstat(server.socketPath)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("missing address", func(t *testing.T) {
+		t.Setenv(workerAddressEnvironmentVariable, "")
+		worker := NewWorker()
+		err := worker.Serve(context.Background())
+		require.ErrorContains(t, err, workerAddressEnvironmentVariable+" is not set")
+		require.ErrorContains(t, worker.RegisterTasks(), "after worker serving has started")
+	})
+
+	t.Run("existing regular file is preserved", func(t *testing.T) {
+		socketPath := filepath.Join(t.TempDir(), "worker.sock")
+		require.NoError(t, os.WriteFile(socketPath, []byte("not a socket"), 0o600))
+		t.Setenv(workerAddressEnvironmentVariable, "unix://"+socketPath)
+		err := NewWorker().Serve(context.Background())
+		require.ErrorContains(t, err, "is not a socket")
+		contents, readErr := os.ReadFile(socketPath)
+		require.NoError(t, readErr)
+		assert.Equal(t, "not a socket", string(contents))
+	})
+
+	t.Run("stale socket is safely replaced and removed", func(t *testing.T) {
+		socketPath := filepath.Join(t.TempDir(), "worker.sock")
+		listener, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", socketPath)
+		require.NoError(t, err)
+		require.NoError(t, listener.Close())
+
+		worker := NewWorker()
+		server := startTestWorkerAt(t, worker, socketPath)
+		server.cancel()
+		require.NoError(t, server.wait(t))
+		_, err = os.Lstat(socketPath)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+}
+
+func TestWorkerCredentialsAreRedacted(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	requestToken := "worker-request-secret-token"
+	environmentToken := "worker-environment-secret-token"
+	t.Setenv("TILEBOX_API_KEY", environmentToken)
+	workerSensitiveValue = requestToken + " " + environmentToken
+	worker := NewWorker()
+	require.NoError(t, worker.RegisterTasks(&workerSensitiveTask{}))
+	server := startTestWorker(t, worker)
+	request := testWorkerInitializationRequest()
+	apiURL := filepath.Join(t.TempDir(), "unused-api.sock")
+	request.SetApiConnection(workflowsv1.TileboxAPIConnection_builder{
+		Url:   &apiURL,
+		Token: &requestToken,
+	}.Build())
+	_, err := server.client.InitializeWorker(context.Background(), request)
+	require.NoError(t, err)
+
+	task := testWorkerTask((&workerSensitiveTask{}).Identifier(), []byte(`{}`))
+	task.SetDisplay("input display " + workerSensitiveValue)
+	response, err := server.client.ExecuteTask(context.Background(), task)
+	require.NoError(t, err)
+	require.NotNil(t, response.GetFailedTask())
+	assert.NotContains(t, response.GetFailedTask().GetDisplay(), requestToken)
+	assert.NotContains(t, response.GetFailedTask().GetDisplay(), environmentToken)
+	assert.Contains(t, response.GetFailedTask().GetDisplay(), "[REDACTED]")
+	assert.NotContains(t, logs.String(), requestToken)
+	assert.NotContains(t, logs.String(), environmentToken)
+}
+
+func TestClientConfigDefaultsURLFromEnvironment(t *testing.T) {
+	t.Setenv("TILEBOX_API_URL", "https://workflows.example.test")
+	t.Setenv("TILEBOX_API_KEY", "")
+	cfg := newClientConfig([]ClientOption{WithHTTPClient(&http.Client{})})
+	assert.Equal(t, "https://workflows.example.test", cfg.url)
+
+	cfg = newClientConfig([]ClientOption{
+		WithHTTPClient(&http.Client{}),
+		WithURL("https://explicit.example.test"),
+	})
+	assert.Equal(t, "https://explicit.example.test", cfg.url)
+}
+
+func TestTaskRunnerKeepsNativeFailureClassification(t *testing.T) {
+	runner, err := newTaskRunner(
+		context.Background(),
+		mockTaskService{},
+		clusterClient{service: &mockClusterService{}},
+		noop.NewTracerProvider().Tracer("test"),
+	)
+	require.NoError(t, err)
+	response, err := runner.ExecuteTask(context.Background(), testWorkerTask(NewTaskIdentifier("unknown", "v1.0"), []byte(`{}`)))
+	require.NoError(t, err)
+	require.NotNil(t, response.GetFailedTask())
+	assert.True(t, response.GetFailedTask().GetWasWorkflowError())
+}

--- a/workflows/v1/worker_unix.go
+++ b/workflows/v1/worker_unix.go
@@ -1,0 +1,105 @@
+//go:build unix
+
+package workflows
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func listenWorker(address string) (net.Listener, func() error, error) {
+	socketPath, err := workerSocketPath(address)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if existing, err := os.Lstat(socketPath); err == nil { //nolint:gosec // The validated absolute path is the local worker socket contract.
+		if existing.Mode()&os.ModeSocket == 0 {
+			return nil, nil, errors.New("worker socket path already exists and is not a socket")
+		}
+
+		dialContext, cancelDial := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		connection, dialErr := (&net.Dialer{}).DialContext(dialContext, "unix", socketPath)
+		cancelDial()
+		if dialErr == nil {
+			_ = connection.Close()
+			return nil, nil, errors.New("worker socket is already in use")
+		}
+		if !errors.Is(dialErr, syscall.ECONNREFUSED) && !errors.Is(dialErr, os.ErrNotExist) {
+			return nil, nil, errors.New("cannot verify existing worker socket")
+		}
+		if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) { //nolint:gosec // Only a verified stale Unix socket is removed.
+			return nil, nil, errors.New("failed to remove stale worker socket")
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, nil, errors.New("failed to inspect worker socket path")
+	}
+
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	if err != nil {
+		return nil, nil, errors.New("failed to bind worker Unix socket")
+	}
+	if err := os.Chmod(socketPath, 0o600); err != nil { //nolint:gosec // The worker must restrict its validated local socket.
+		_ = listener.Close()
+		_ = os.Remove(socketPath) //nolint:gosec // The validated socket created immediately above is removed.
+		return nil, nil, errors.New("failed to secure worker Unix socket")
+	}
+	createdSocket, err := os.Lstat(socketPath) //nolint:gosec // The validated socket created immediately above is inspected.
+	if err != nil {
+		_ = listener.Close()
+		_ = os.Remove(socketPath) //nolint:gosec // The validated socket created immediately above is removed.
+		return nil, nil, errors.New("failed to inspect bound worker Unix socket")
+	}
+
+	cleanup := func() error {
+		closeErr := listener.Close()
+		if errors.Is(closeErr, net.ErrClosed) {
+			closeErr = nil
+		}
+
+		currentSocket, err := os.Lstat(socketPath) //nolint:gosec // The validated socket owned by this listener is inspected.
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			return closeErr
+		case err != nil:
+			return errors.Join(closeErr, errors.New("failed to inspect worker socket during cleanup"))
+		case !os.SameFile(createdSocket, currentSocket):
+			return errors.Join(closeErr, errors.New("worker socket path was replaced before cleanup"))
+		case currentSocket.Mode()&os.ModeSocket == 0:
+			return errors.Join(closeErr, errors.New("worker socket path is no longer a socket"))
+		default:
+			return errors.Join(closeErr, os.Remove(socketPath)) //nolint:gosec // SameFile verified that this is the socket created above.
+		}
+	}
+	return listener, cleanup, nil
+}
+
+func workerSocketPath(address string) (string, error) {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return "", fmt.Errorf("%s is not set", workerAddressEnvironmentVariable)
+	}
+
+	var socketPath string
+	switch {
+	case strings.HasPrefix(address, "unix://"):
+		socketPath = strings.TrimPrefix(address, "unix://")
+	case strings.HasPrefix(address, "unix:"):
+		socketPath = strings.TrimPrefix(address, "unix:")
+	default:
+		return "", errors.New("worker address must use the unix:// transport")
+	}
+
+	socketPath = filepath.Clean(socketPath)
+	if !filepath.IsAbs(socketPath) || socketPath == string(filepath.Separator) {
+		return "", errors.New("worker Unix socket path must be absolute")
+	}
+	return socketPath, nil
+}


### PR DESCRIPTION
## Summary

- add the public execution-only Go workflow Worker API used by `tilebox runner start`
- share task registration and execution semantics with native TaskRunner
- implement lifecycle-safe WorkerService serving over the existing private Unix-socket protocol
- add real grpc-go and Connect-over-gRPC integration coverage, shutdown/cancellation/race/security tests, and a complete release-worker example
- honor `TILEBOX_API_URL` consistently and clean up Worker-owned telemetry

## Validation

- `go test ./...`
- `go test -race ./workflows/v1`
- `go build ./...`
- `golangci-lint run ./...`
- Windows amd64 cross-build
- Darwin arm64 cross-build
- `git diff --check`

No generated protobuf/API files changed.